### PR TITLE
Add Paranoia game section

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
                 <li><a href="#narrative">Narrative Summary</a></li>
                 <li><a href="#timeline">Timeline</a></li>
                 <li><a href="#appendix">Appendix</a></li>
+                <li><a href="paranoia/index.html">Paranoia</a></li>
             </ul>
         </nav>
     </header>

--- a/paranoia/blog.html
+++ b/paranoia/blog.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paranoia Blog</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Paranoia: Alpha Complex</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="blog.html">Blog</a></li>
+                <li><a href="house-rules.html">House Rules</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>Blog</h2>
+            <p>Posts will appear here as missions unfold.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+    </footer>
+</body>
+</html>

--- a/paranoia/house-rules.html
+++ b/paranoia/house-rules.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paranoia House Rules</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Paranoia: Alpha Complex</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="blog.html">Blog</a></li>
+                <li><a href="house-rules.html">House Rules</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>House Rules</h2>
+            <p>The Computer will provide additional directives soon.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+    </footer>
+</body>
+</html>

--- a/paranoia/index.html
+++ b/paranoia/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paranoia: Alpha Complex</title>
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Paranoia: Alpha Complex</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="blog.html">Blog</a></li>
+                <li><a href="house-rules.html">House Rules</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>Welcome, Citizen</h2>
+            <p>Congratulations, Citizen! You’ve been selected for a very special mission in Alpha Complex — a world where a cheerful but slightly unhinged AI insists it’s always right, treason is always fatal, and death is just another scheduling inconvenience.</p>
+            <p>Expect claustrophobic corridors, malfunctioning tech, strange mutant abilities you probably shouldn’t use in public, and missions so simple they can only go spectacularly wrong. Imagine a blend of sci-fi satire and a deadly game show, with the chaotic dungeon-crawl energy of <em>Dungeon Crawler Carl</em>: slapstick danger, suspiciously cheerful corporate propaganda, and an audience that seems to be laughing at you as much as with you.</p>
+            <p>This is a game where your character may explode, reclone, or become the proud new owner of a sponsor-branded gadget you never wanted — all in the name of loyalty, ratings, and survival. You’ll laugh, you’ll panic, you’ll probably explode… and then you’ll come right back for more.</p>
+        </section>
+        <section>
+            <h2>The Elevator Pitch — How We’ll Play</h2>
+            <ul>
+                <li><strong>System:</strong> A fast, home-brewed Paranoia remix with dungeon-crawl absurdity.</li>
+                <li><strong>Platform:</strong> Roll20 (maps, tokens, mayhem).</li>
+                <li><strong>Comms:</strong> Zoom audio only — no webcams, no pressure.</li>
+                <li><strong>Session Length:</strong> 3–4 hours per evening.</li>
+                <li><strong>Commitment:</strong> Try one game, no strings attached.</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Paranoia area with styled index, blog, and house-rules pages.
- Link Paranoia section from main announcements navigation.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab29b3e78483339f9df0fe6df261ea