### PR TITLE
Add New Horizons arc and dynamic timeline

### DIFF
--- a/PartEight.html
+++ b/PartEight.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Part 8: Windglum (Pandemonium)</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
+        <nav>
+            <ul>
+                <li><a href="index.html">Maps</a></li>
+                <li><a href="index.html#narrative">Narrative Summary</a></li>
+                <li><a href="index.html#timeline">Timeline</a></li>
+                <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <h2>Part 8: Windglum (Pandemonium)</h2>
+        <p><em>Placeholder scene text. Boss will replace with final narration.</em></p>
+
+        <h3>Key Locations</h3>
+        <ul>
+          <li><em>Placeholder location 1</em></li>
+          <li><em>Placeholder location 2</em></li>
+        </ul>
+
+        <h3>Allies &amp; Factions</h3>
+        <ul>
+          <li><em>Church of Reclamation (Red Keep)</em></li>
+          <li><em>Refugees of Rigus</em></li>
+        </ul>
+
+        <h3>Opposition</h3>
+        <ul>
+          <li><em>Demon Occupation Forces</em></li>
+        </ul>
+
+        <h3>Objectives</h3>
+        <ol>
+          <li><em>Objective placeholder A</em></li>
+          <li><em>Objective placeholder B</em></li>
+        </ol>
+
+        <h3>Aftermath</h3>
+        <p><em>Placeholder outcome notes.</em></p>
+    </main>
+
+    <footer>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
+    </footer>
+</body>
+</html>
+

--- a/PartFive.html
+++ b/PartFive.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Part 5: Arrival at the Red Keep (Acheron)</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
+        <nav>
+            <ul>
+                <li><a href="index.html">Maps</a></li>
+                <li><a href="index.html#narrative">Narrative Summary</a></li>
+                <li><a href="index.html#timeline">Timeline</a></li>
+                <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <h2>Part 5: Arrival at the Red Keep (Acheron)</h2>
+        <p><em>Placeholder scene text. Boss will replace with final narration.</em></p>
+
+        <h3>Key Locations</h3>
+        <ul>
+          <li><em>Placeholder location 1</em></li>
+          <li><em>Placeholder location 2</em></li>
+        </ul>
+
+        <h3>Allies &amp; Factions</h3>
+        <ul>
+          <li><em>Church of Reclamation (Red Keep)</em></li>
+          <li><em>Refugees of Rigus</em></li>
+        </ul>
+
+        <h3>Opposition</h3>
+        <ul>
+          <li><em>Demon Occupation Forces</em></li>
+        </ul>
+
+        <h3>Objectives</h3>
+        <ol>
+          <li><em>Objective placeholder A</em></li>
+          <li><em>Objective placeholder B</em></li>
+        </ol>
+
+        <h3>Aftermath</h3>
+        <p><em>Placeholder outcome notes.</em></p>
+    </main>
+
+    <footer>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
+    </footer>
+</body>
+</html>
+

--- a/PartFour.html
+++ b/PartFour.html
@@ -9,12 +9,14 @@
 <body>
     <header>
         <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
         <nav>
             <ul>
                 <li><a href="index.html">Maps</a></li>
                 <li><a href="index.html#narrative">Narrative Summary</a></li>
                 <li><a href="index.html#timeline">Timeline</a></li>
                 <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
             </ul>
         </nav>
     </header>
@@ -70,7 +72,7 @@
 </main>
 
     <footer>
-        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
     </footer>
 </body>
 </html>

--- a/PartOne.html
+++ b/PartOne.html
@@ -9,12 +9,14 @@
 <body>
     <header>
         <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
         <nav>
             <ul>
                 <li><a href="index.html">Maps</a></li>
                 <li><a href="index.html#narrative">Narrative Summary</a></li>
                 <li><a href="index.html#timeline">Timeline</a></li>
                 <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
             </ul>
         </nav>
     </header>
@@ -85,7 +87,7 @@
 </main>
 
     <footer>
-        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
     </footer>
 </body>
 </html>

--- a/PartSeven.html
+++ b/PartSeven.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Part 7: The Reality Wrinkle (Material Plane)</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
+        <nav>
+            <ul>
+                <li><a href="index.html">Maps</a></li>
+                <li><a href="index.html#narrative">Narrative Summary</a></li>
+                <li><a href="index.html#timeline">Timeline</a></li>
+                <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <h2>Part 7: The Reality Wrinkle (Material Plane)</h2>
+        <p><em>Placeholder scene text. Boss will replace with final narration.</em></p>
+
+        <h3>Key Locations</h3>
+        <ul>
+          <li><em>Placeholder location 1</em></li>
+          <li><em>Placeholder location 2</em></li>
+        </ul>
+
+        <h3>Allies &amp; Factions</h3>
+        <ul>
+          <li><em>Church of Reclamation (Red Keep)</em></li>
+          <li><em>Refugees of Rigus</em></li>
+        </ul>
+
+        <h3>Opposition</h3>
+        <ul>
+          <li><em>Demon Occupation Forces</em></li>
+        </ul>
+
+        <h3>Objectives</h3>
+        <ol>
+          <li><em>Objective placeholder A</em></li>
+          <li><em>Objective placeholder B</em></li>
+        </ol>
+
+        <h3>Aftermath</h3>
+        <p><em>Placeholder outcome notes.</em></p>
+    </main>
+
+    <footer>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
+    </footer>
+</body>
+</html>
+

--- a/PartSix.html
+++ b/PartSix.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Part 6: Through Rigus to the Brindinford Gate</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
+        <nav>
+            <ul>
+                <li><a href="index.html">Maps</a></li>
+                <li><a href="index.html#narrative">Narrative Summary</a></li>
+                <li><a href="index.html#timeline">Timeline</a></li>
+                <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <h2>Part 6: Through Rigus to the Brindinford Gate</h2>
+        <p><em>Placeholder scene text. Boss will replace with final narration.</em></p>
+
+        <h3>Key Locations</h3>
+        <ul>
+          <li><em>Placeholder location 1</em></li>
+          <li><em>Placeholder location 2</em></li>
+        </ul>
+
+        <h3>Allies &amp; Factions</h3>
+        <ul>
+          <li><em>Church of Reclamation (Red Keep)</em></li>
+          <li><em>Refugees of Rigus</em></li>
+        </ul>
+
+        <h3>Opposition</h3>
+        <ul>
+          <li><em>Demon Occupation Forces</em></li>
+        </ul>
+
+        <h3>Objectives</h3>
+        <ol>
+          <li><em>Objective placeholder A</em></li>
+          <li><em>Objective placeholder B</em></li>
+        </ol>
+
+        <h3>Aftermath</h3>
+        <p><em>Placeholder outcome notes.</em></p>
+    </main>
+
+    <footer>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
+    </footer>
+</body>
+</html>
+

--- a/PartThree.html
+++ b/PartThree.html
@@ -10,12 +10,14 @@
 <body>
     <header>
         <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
         <nav>
             <ul>
                 <li><a href="index.html">Maps</a></li>
                 <li><a href="index.html#narrative">Narrative Summary</a></li>
                 <li><a href="index.html#timeline">Timeline</a></li>
                 <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
             </ul>
         </nav>
     </header>
@@ -76,7 +78,7 @@
     </main>
 
     <footer>
-        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
     </footer>
 </body>
 </html>

--- a/PartTwo.html
+++ b/PartTwo.html
@@ -9,12 +9,14 @@
 <body>
     <header>
         <h1>The Frostbitten Chronicles of Team Biscuit</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
         <nav>
             <ul>
                 <li><a href="index.html">Maps</a></li>
                 <li><a href="index.html#narrative">Narrative Summary</a></li>
                 <li><a href="index.html#timeline">Timeline</a></li>
                 <li><a href="index.html#appendix">Appendix</a></li>
+                <li><a href="index.html#new-horizons">New Horizons</a></li>
             </ul>
         </nav>
     </header>
@@ -75,7 +77,7 @@
 </main>
 
     <footer>
-        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
     </footer>
 </body>
 </html>

--- a/data/timeline.json
+++ b/data/timeline.json
@@ -1,0 +1,16 @@
+[
+  {"date":"1406-08-27","title":"Arrived at Bryn Shander, ruins sighted","notes":"Horde moved north."},
+  {"date":"1406-08-25","title":"Defeated Vellynne and the Twisted Darlings","notes":"Legendary weapons recovered."},
+  {"date":"1406-08-17","title":"Arrived at the Lost Spire","notes":"Descent beneath the black mountain began."},
+  {"date":"1406-08-14","title":"Returned to Easthaven after Emperor Penguin raid","notes":"Preparing to pursue clues to the Lost Spire of Netheril."},
+  {"date":"1406-08-10","title":"Cave of the Berserkers","notes":"Defeated the Keraptis Clone and retrieved Frostrazor."},
+  {"date":"1406-01-30","title":"Side Quests to Gather Intel","notes":"Completed minor quests about Frostmaiden's followers."},
+  {"date":"1406-01-24","title":"Frostmaiden’s Followers and Frost Druid Cults","notes":"Defeated corrupted frost druids, uncovering the Whispering Willow Wood."},
+  {"date":"1406-01-10","title":"Arcane Brotherhood","notes":"Uncovered clues about Pengu, Auril, and the Candle of the Dark One."},
+  {"date":"1406-01-01","title":"Investigate the Duergar Conspiracy","notes":"Stopped the duergar plot in Icewind Dale."},
+  {"date":"1405-12-23","title":"A Beautiful Mine (Termalaine)","notes":"Resolved the mine’s corruption; town stable."},
+  {"date":"1405-12-16","title":"Foaming Mugs (Bryn Shander)","notes":"Discovered the Potion of Giant Size in a smuggling operation."},
+  {"date":"1405-12-02","title":"The Easthaven Ferry","notes":"Ensured ferry operation and resolved duergar threat."},
+  {"date":"1405-04-24","title":"The White Lady’s Ghost","notes":"Laid the spirit to rest and found the Ring of Invisibility."},
+  {"date":"1405-04-10","title":"Toil and Trouble","notes":"Retrieved the magical cauldron from the Frost Giants."}
+]

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en"></html>
+<html lang="en">
 <head>
-    <meta charset="""UTF-8">
-    <meta name="viewport" content="""width=device-width, initial-scale=""1.0">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Announcements</title>
     <link rel="stylesheet" href="styles.css">
     <style>
@@ -19,18 +19,38 @@
 <body>
     <header>
         <h1>Campaign Announcements</h1>
+        <p class="subtitle">New Arc: “New Horizons” — Acheron → Rigus → Brindinford → Windglum (Pandemonium)</p>
         <nav>
             <ul>
-                <li><a href="">Maps</a></li>
+                <li><a href="#map">Maps</a></li>
                 <li><a href="#narrative">Narrative Summary</a></li>
                 <li><a href="#timeline">Timeline</a></li>
                 <li><a href="#appendix">Appendix</a></li>
+                <li><a href="#new-horizons">New Horizons</a></li>
             </ul>
         </nav>
     </header>
-</body>
-</hr>
-<br>
+
+    <section id="new-horizons">
+      <h2>Now Playing: New Horizons</h2>
+      <p><em>Current arc summary goes here.</em> <!-- TODO: Boss will replace --></p>
+      <ol>
+        <li>Lion’s Gate → Demon-occupied Rigus</li>
+        <li>Ruin outside Rigus → Portal to Brindinford</li>
+        <li>Reality Wrinkle ruins (Material Plane) → Stabilize the portal</li>
+        <li>Windglum (Pandemonium) → Reality Wrinkle shop</li>
+      </ol>
+      <p><strong>Status:</strong> <em>Placeholders until Boss fills in.</em></p>
+      <div class="quick-links">
+        <h3>Quick Links</h3>
+        <ul>
+          <li><a href="PartFive.html">Part Five: Arrival at the Red Keep (Acheron)</a></li>
+          <li><a href="PartSix.html">Part Six: Through Rigus to the Brindinford Gate</a></li>
+          <li><a href="PartSeven.html">Part Seven: The Reality Wrinkle (Material)</a></li>
+          <li><a href="PartEight.html">Part Eight: Windglum (Pandemonium)</a></li>
+        </ul>
+      </div>
+    </section>
     <a href="BlizzardCrawl.html" style="text-decoration: none; color: inherit; display: block; border: 3px solid blue; padding: 10px; margin-bottom: 20px; border-radius: 15px; background-color: #f5deb3;">
         <!-- Banner Image -->
         <div style="text-align: center; margin-bottom: 20px;">
@@ -61,6 +81,10 @@
             <li><a href="PartTwo.html" class="announcement-link">Part Two: The Quest for the Cauldron</a></li>
             <li><a href="PartThree.html" class="announcement-link">Part Three: The Rise of the Duergar</a></li>
             <li><a href="PartFour.html" class="announcement-link">Part Four: Battle in the Berserker Cave</a></li>
+            <li><a href="PartFive.html" class="announcement-link">Part Five: Arrival at the Red Keep (Acheron)</a></li>
+            <li><a href="PartSix.html" class="announcement-link">Part Six: Through Rigus to the Brindinford Gate</a></li>
+            <li><a href="PartSeven.html" class="announcement-link">Part Seven: The Reality Wrinkle (Material)</a></li>
+            <li><a href="PartEight.html" class="announcement-link">Part Eight: Windglum (Pandemonium)</a></li>
         </ul>
         <br><hr><br>
         <ul>
@@ -78,78 +102,7 @@
         <div class="journal-entry">
             <div class="journal-entry-title">Timeline of Quests Completed<hr></div>
             <div class="journal-entry-content">
-                <ol>
-                    <li><strong>Third-day, 27th of Eleasis, 1406</strong>
-                        <ul>
-                            <li>Arrived at Bryn Shander, to find it in ruins. Horde has been sighted moving off into the distance, ever northward.</li>
-                        </ul>
-                    </li>
-                    <li><strong>First-day, 25th of Eleasis, 1406</strong>
-                        <ul>
-                            <li>Return to Easthaven after successfully defeating Vellynne and the Twisted Darlings. Still no closer to Pengu, and no clues.  Legendary Weapons recovered!</li>
-                        </ul>
-                    </li>
-                    <li><strong>Eight-day, 17th of Eleasis, 1406</strong>
-                        <ul>
-                            <li>Party finally arrves at The Lost Spire, and begins their descent into the deep ice below the black mountain.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 14th of Eleasis, 1406</strong>
-                        <ul>
-                            <li>Returned to <strong>Easthaven</strong> after the <strong>Emperor Penguin</strong> raid. Now preparing to pursue the clues leading to the <strong>Lost Spire of Netheril</strong>.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 10th of Eleasis, 1406</strong>
-                        <ul>
-                            <li><strong>Cave of the Berserkers</strong>: Defeated the <strong>Keraptis Clone</strong> and retrieved <strong>Frostrazor</strong>.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Eighth-day, 30th of Hammer, 1406</strong>
-                        <ul>
-                            <li><strong>Side Quests to Gather Intel</strong>: Completed several minor quests to gather information about the Frostmaiden’s followers.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 24th of Hammer, 1406</strong>
-                        <ul>
-                            <li><strong>Frostmaiden’s Followers and Frost Druid Cults</strong>: Defeated corrupted frost druids, uncovering the <strong>Whispering Willow Wood</strong>.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 10th of Hammer, 1406</strong>
-                        <ul>
-                            <li><strong>Arcane Brotherhood</strong>: The party uncovered clues about <strong>Pengu</strong>, <strong>Auril</strong>, and the <strong>Candle of the Dark One</strong> during this storyline.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 1st of Hammer, 1406</strong>
-                        <ul>
-                            <li><strong>Investigate the Duergar Conspiracy</strong>: Stopped the duergar plot and thwarted their plans in Icewind Dale.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Seventh-day, 23rd of Nightal, 1405</strong>
-                        <ul>
-                            <li><strong>A Beautiful Mine (Termalaine)</strong>: Resolved the mine’s corruption and helped the town return to stability.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Ninth-day, 16th of Nightal, 1405</strong>
-                        <ul>
-                            <li><strong>Foaming Mugs (Bryn Shander)</strong>: Completed this quest, discovering the <strong>Potion of Giant Size</strong> in the smuggling operation.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Seventh-day, 2nd of Nightal, 1405</strong>
-                        <ul>
-                            <li><strong>The Easthaven Ferry</strong>: Ensured the ferry’s continued operation and resolved the duergar threat in the town.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 24th of Tarsakh, 1405</strong>
-                        <ul>
-                            <li><strong>The White Lady’s Ghost</strong>: The party laid the spirit of the White Lady to rest, discovering the <strong>Ring of Invisibility</strong>.</li>
-                        </ul>
-                    </li>
-                    <li><strong>Fifth-day, 10th of Tarsakh, 1405</strong>
-                        <ul>
-                            <li><strong>Toil and Trouble</strong>: Completed after retrieving the magical cauldron from the Frost Giants and returning it to Easthaven.</li>
-                        </ul>
-                    </li>
-                </ol>
+                <ol id="timeline-list"></ol>
             </div>
         </div>
         </section>
@@ -261,8 +214,21 @@
     </main>
 
     <footer>
-        <p>&copy; 2024 Campaign Chronicles. All Rights Reserved.</p>
+        <p>© Campaign Chronicles. “New Horizons” arc placeholders present — will be filled by GM.</p>
     </footer>
+
+    <script>
+        fetch('data/timeline.json')
+            .then(response => response.json())
+            .then(entries => {
+                const list = document.getElementById('timeline-list');
+                entries.forEach(entry => {
+                    const li = document.createElement('li');
+                    li.innerHTML = `<strong>${entry.date}</strong><ul><li>${entry.title}${entry.notes ? ' — ' + entry.notes : ''}</li></ul>`;
+                    list.appendChild(li);
+                });
+            });
+    </script>
 
     <script>
         document.getElementById('thumbnail').addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- introduce "Now Playing: New Horizons" homepage section with quick links to new arc
- convert timeline to use data/timeline.json
- scaffold Parts 5–8 with placeholder content and shared navigation
- fix index structure and embed quick links within arc section

## Testing
- `python -m json.tool data/timeline.json`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d999fb0833383f59226bccf9a3b